### PR TITLE
[chakra][et_jsonizer] Use the latest schema

### DIFF
--- a/utils/et_jsonizer/et_jsonizer.py
+++ b/utils/et_jsonizer/et_jsonizer.py
@@ -10,6 +10,7 @@ from chakra.third_party.utils.protolib import (
 )
 
 from chakra.et_def.et_def_pb2 import (
+    GlobalMetadata,
     Node as ChakraNode,
 )
 
@@ -37,6 +38,9 @@ def main() -> None:
     et = open_file_rd(args.input_filename)
     node = ChakraNode()
     with open(args.output_filename, 'w') as f:
+        gm = GlobalMetadata()
+        decode_message(et, gm)
+        f.write(MessageToJson(gm))
         while decode_message(et, node):
             f.write(MessageToJson(node))
     et.close()


### PR DESCRIPTION
## Summary
This pull request updates et_jsonizer to align with Chakra schema v0.0.4, specifically by ensuring that global metadata is read at the start.

## Test Plan
```
$ pip3 install .
$ python3 -m chakra.et_generator.et_generator --num_npus 64 --num_dims 1
$ python3 -m chakra.et_jsonizer.et_jsonizer --input_file one_comp_node.0.et --output_file one_comp_node.0.json
$ cat one_comp_node.0.json
{
  "version": "0.0.4"
}{
  "id": "192",
  "name": "COMP_NODE",
  "type": "COMP_NODE",
  "durationMicros": "5"
}
```