### PR TITLE
Reformat C++ codes with clang-format and introduce C++ linting via GitHub actions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ForEachMacros: [ FOR_EACH_RANGE, FOR_EACH, ]
+IncludeCategories:
+  - Regex: '^<.*\.h(pp)?>'
+    Priority: 1
+  - Regex: '^<.*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IndentCaseLabels: true
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 2000000
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 8
+UseTab: Never
+...

--- a/.github/workflows/cpp_lint.yml
+++ b/.github/workflows/cpp_lint.yml
@@ -1,0 +1,15 @@
+name: Clang-format Full Tree
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.11
+      with:
+        source: '.'
+        extensions: 'cc,cpp,h,hh'
+        clangFormatVersion: 11
+        style: file

--- a/et_feeder/et_feeder.h
+++ b/et_feeder/et_feeder.h
@@ -6,14 +6,17 @@
 #include <unordered_set>
 #include <vector>
 
-#include "third_party/utils/protoio.hh"
 #include "et_feeder/et_feeder_node.h"
+#include "third_party/utils/protoio.hh"
 
 namespace Chakra {
-struct CompareNodes: public std::binary_function<std::shared_ptr<ETFeederNode>, std::shared_ptr<ETFeederNode>, bool>
-{
-  bool operator()(const std::shared_ptr<ETFeederNode> lhs, const std::shared_ptr<ETFeederNode> rhs) const
-  {
+struct CompareNodes : public std::binary_function<
+                          std::shared_ptr<ETFeederNode>,
+                          std::shared_ptr<ETFeederNode>,
+                          bool> {
+  bool operator()(
+      const std::shared_ptr<ETFeederNode> lhs,
+      const std::shared_ptr<ETFeederNode> rhs) const {
     return lhs->getChakraNode()->id() > rhs->getChakraNode()->id();
   }
 };
@@ -43,7 +46,11 @@ class ETFeeder {
 
   std::unordered_map<uint64_t, std::shared_ptr<ETFeederNode>> dep_graph_{};
   std::unordered_set<uint64_t> dep_free_node_id_set_{};
-  std::priority_queue<std::shared_ptr<ETFeederNode>, std::vector<std::shared_ptr<ETFeederNode>>, CompareNodes> dep_free_node_queue_{};
+  std::priority_queue<
+      std::shared_ptr<ETFeederNode>,
+      std::vector<std::shared_ptr<ETFeederNode>>,
+      CompareNodes>
+      dep_free_node_queue_{};
   std::unordered_set<std::shared_ptr<ETFeederNode>> dep_unresolved_node_set_{};
 };
 

--- a/et_feeder/et_feeder_node.cpp
+++ b/et_feeder/et_feeder_node.cpp
@@ -4,7 +4,7 @@ using namespace std;
 using namespace Chakra;
 
 ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
-  this->node_= node;
+  this->node_ = node;
   this->id_ = node->id();
   this->name_ = node->name();
   this->runtime_ = node->duration_micros();
@@ -12,26 +12,26 @@ ETFeederNode::ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node) {
   for (int i = 0; i < node->attr_size(); i++) {
     string attr_name = node->attr(i).name();
     if (attr_name == "is_cpu_op") {
-      assign_attr_val(node, i, (void *)(&is_cpu_op_));
+      assign_attr_val(node, i, (void*)(&is_cpu_op_));
     } else if (attr_name == "num_ops") {
-      assign_attr_val(node, i, (void *)(&num_ops_));
+      assign_attr_val(node, i, (void*)(&num_ops_));
     } else if (attr_name == "tensor_size") {
-      assign_attr_val(node, i, (void *)(&tensor_size_));
+      assign_attr_val(node, i, (void*)(&tensor_size_));
     } else if (attr_name == "comm_type") {
-      assign_attr_val(node, i, (void *)(&comm_type_));
+      assign_attr_val(node, i, (void*)(&comm_type_));
     } else if (attr_name == "involved_dim") {
-      assign_attr_val(node, i, (void *)(&involved_dim_));
+      assign_attr_val(node, i, (void*)(&involved_dim_));
       involved_dim_size_ = node->attr(i).bool_list().values_size();
     } else if (attr_name == "comm_priority") {
-      assign_attr_val(node, i, (void *)(&comm_priority_));
+      assign_attr_val(node, i, (void*)(&comm_priority_));
     } else if (attr_name == "comm_size") {
-      assign_attr_val(node, i, (void *)(&comm_size_));
+      assign_attr_val(node, i, (void*)(&comm_size_));
     } else if (attr_name == "comm_src") {
-      assign_attr_val(node, i, (void *)(&comm_src_));
+      assign_attr_val(node, i, (void*)(&comm_src_));
     } else if (attr_name == "comm_dst") {
-      assign_attr_val(node, i, (void *)(&comm_dst_));
+      assign_attr_val(node, i, (void*)(&comm_dst_));
     } else if (attr_name == "comm_tag") {
-      assign_attr_val(node, i, (void *)(&comm_tag_));
+      assign_attr_val(node, i, (void*)(&comm_tag_));
     }
   }
 }
@@ -67,127 +67,130 @@ void ETFeederNode::setDepUnresolvedParentIDs(
   dep_unresolved_parent_ids_ = dep_unresolved_parent_ids;
 }
 
-void ETFeederNode::assign_attr_val(shared_ptr<ChakraProtoMsg::Node> node, int i, void *member) {
+void ETFeederNode::assign_attr_val(
+    shared_ptr<ChakraProtoMsg::Node> node,
+    int i,
+    void* member) {
   auto attr = node->attr(i);
-  switch(attr.value_case()) {
+  switch (attr.value_case()) {
     case ChakraProtoMsg::AttributeProto::kDoubleVal:
-      *((double *)member) = attr.double_val();
+      *((double*)member) = attr.double_val();
       break;
     case ChakraProtoMsg::AttributeProto::kDoubleList:
       for (const auto& val : attr.double_list().values()) {
-        (*((std::vector<double> *)member)).push_back(val);
+        (*((std::vector<double>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kFloatVal:
-      *((float *)member) = attr.float_val();
+      *((float*)member) = attr.float_val();
       break;
     case ChakraProtoMsg::AttributeProto::kFloatList:
       for (const auto& val : attr.float_list().values()) {
-        (*((std::vector<float> *)member)).push_back(val);
+        (*((std::vector<float>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kInt32Val:
-      *((int32_t *)member) = attr.int32_val();
+      *((int32_t*)member) = attr.int32_val();
       break;
     case ChakraProtoMsg::AttributeProto::kInt32List:
       for (const auto& val : attr.int32_list().values()) {
-        (*((std::vector<int32_t> *)member)).push_back(val);
+        (*((std::vector<int32_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kInt64Val:
-      *((int64_t *)member) = attr.int64_val();
+      *((int64_t*)member) = attr.int64_val();
       break;
     case ChakraProtoMsg::AttributeProto::kInt64List:
       for (const auto& val : attr.int64_list().values()) {
-        (*((std::vector<int64_t> *)member)).push_back(val);
+        (*((std::vector<int64_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kUint32Val:
-      *((uint32_t *)member) = attr.uint32_val();
+      *((uint32_t*)member) = attr.uint32_val();
       break;
     case ChakraProtoMsg::AttributeProto::kUint32List:
       for (const auto& val : attr.uint32_list().values()) {
-        (*((std::vector<uint32_t> *)member)).push_back(val);
+        (*((std::vector<uint32_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kUint64Val:
-      *((uint64_t *)member) = attr.uint64_val();
+      *((uint64_t*)member) = attr.uint64_val();
       break;
     case ChakraProtoMsg::AttributeProto::kUint64List:
       for (const auto& val : attr.uint64_list().values()) {
-        (*((std::vector<uint64_t> *)member)).push_back(val);
+        (*((std::vector<uint64_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kSint32Val:
-      *((int32_t *)member) = attr.sint32_val();
+      *((int32_t*)member) = attr.sint32_val();
       break;
     case ChakraProtoMsg::AttributeProto::kSint32List:
       for (const auto& val : attr.sint32_list().values()) {
-        (*((std::vector<int32_t> *)member)).push_back(val);
+        (*((std::vector<int32_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kSint64Val:
-      *((int64_t *)member) = attr.sint64_val();
+      *((int64_t*)member) = attr.sint64_val();
       break;
     case ChakraProtoMsg::AttributeProto::kSint64List:
       for (const auto& val : attr.sint64_list().values()) {
-        (*((std::vector<int64_t> *)member)).push_back(val);
+        (*((std::vector<int64_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kFixed32Val:
-      *((uint32_t *)member) = attr.fixed32_val();
+      *((uint32_t*)member) = attr.fixed32_val();
       break;
     case ChakraProtoMsg::AttributeProto::kFixed32List:
       for (const auto& val : attr.fixed32_list().values()) {
-        (*((std::vector<uint32_t> *)member)).push_back(val);
+        (*((std::vector<uint32_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kFixed64Val:
-      *((uint64_t *)member) = attr.fixed64_val();
+      *((uint64_t*)member) = attr.fixed64_val();
       break;
     case ChakraProtoMsg::AttributeProto::kFixed64List:
       for (const auto& val : attr.fixed64_list().values()) {
-        (*((std::vector<uint64_t> *)member)).push_back(val);
+        (*((std::vector<uint64_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kSfixed32Val:
-      *((int32_t *)member) = attr.sfixed32_val();
+      *((int32_t*)member) = attr.sfixed32_val();
       break;
     case ChakraProtoMsg::AttributeProto::kSfixed32List:
       for (const auto& val : attr.sfixed32_list().values()) {
-        (*((std::vector<int32_t> *)member)).push_back(val);
+        (*((std::vector<int32_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kSfixed64Val:
-      *((int64_t *)member) = attr.sfixed64_val();
+      *((int64_t*)member) = attr.sfixed64_val();
       break;
     case ChakraProtoMsg::AttributeProto::kSfixed64List:
       for (const auto& val : attr.sfixed64_list().values()) {
-        (*((std::vector<int64_t> *)member)).push_back(val);
+        (*((std::vector<int64_t>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kBoolVal:
-      *((bool *)member) = attr.bool_val();
+      *((bool*)member) = attr.bool_val();
       break;
     case ChakraProtoMsg::AttributeProto::kBoolList:
       for (const auto& val : attr.bool_list().values()) {
-        (*((std::vector<bool> *)member)).push_back(val);
+        (*((std::vector<bool>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kStringVal:
-      *((std::string *)member) = attr.string_val();
+      *((std::string*)member) = attr.string_val();
       break;
     case ChakraProtoMsg::AttributeProto::kStringList:
       for (const auto& val : attr.string_list().values()) {
-        (*((std::vector<std::string> *)member)).push_back(val);
+        (*((std::vector<std::string>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::kBytesVal:
-      *((std::string *)member) = attr.bytes_val();
+      *((std::string*)member) = attr.bytes_val();
       break;
     case ChakraProtoMsg::AttributeProto::kBytesList:
       for (const auto& val : attr.bytes_list().values()) {
-        (*((std::vector<std::string> *)member)).push_back(val);
+        (*((std::vector<std::string>*)member)).push_back(val);
       }
       break;
     case ChakraProtoMsg::AttributeProto::VALUE_NOT_SET:

--- a/et_feeder/et_feeder_node.h
+++ b/et_feeder/et_feeder_node.h
@@ -9,55 +9,59 @@
 namespace Chakra {
 
 class ETFeederNode {
-  public:
-    ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node);
-    std::shared_ptr<ChakraProtoMsg::Node> getChakraNode();
-    void addChild(std::shared_ptr<ETFeederNode> node);
-    std::vector<std::shared_ptr<ETFeederNode>> getChildren();
-    void addDepUnresolvedParentID(uint64_t node_id);
-    std::vector<uint64_t> getDepUnresolvedParentIDs();
-    void setDepUnresolvedParentIDs(std::vector<uint64_t> const& dep_unresolved_parent_ids);
+ public:
+  ETFeederNode(std::shared_ptr<ChakraProtoMsg::Node> node);
+  std::shared_ptr<ChakraProtoMsg::Node> getChakraNode();
+  void addChild(std::shared_ptr<ETFeederNode> node);
+  std::vector<std::shared_ptr<ETFeederNode>> getChildren();
+  void addDepUnresolvedParentID(uint64_t node_id);
+  std::vector<uint64_t> getDepUnresolvedParentIDs();
+  void setDepUnresolvedParentIDs(
+      std::vector<uint64_t> const& dep_unresolved_parent_ids);
 
-    uint64_t id();
-    std::string name();
-    bool is_cpu_op();
-    ChakraProtoMsg::NodeType type();
-    uint64_t runtime();
-    uint64_t num_ops();
-    uint32_t tensor_loc();
-    uint64_t tensor_size();
-    ChakraProtoMsg::CollectiveCommType comm_type();
-    uint32_t involved_dim_size();
-    bool involved_dim(int i);
-    uint32_t comm_priority();
-    uint64_t comm_size();
-    uint32_t comm_src();
-    uint32_t comm_dst();
-    uint32_t comm_tag();
+  uint64_t id();
+  std::string name();
+  bool is_cpu_op();
+  ChakraProtoMsg::NodeType type();
+  uint64_t runtime();
+  uint64_t num_ops();
+  uint32_t tensor_loc();
+  uint64_t tensor_size();
+  ChakraProtoMsg::CollectiveCommType comm_type();
+  uint32_t involved_dim_size();
+  bool involved_dim(int i);
+  uint32_t comm_priority();
+  uint64_t comm_size();
+  uint32_t comm_src();
+  uint32_t comm_dst();
+  uint32_t comm_tag();
 
-  private:
-    void assign_attr_val(std::shared_ptr<ChakraProtoMsg::Node> node, int i, void *member);
+ private:
+  void assign_attr_val(
+      std::shared_ptr<ChakraProtoMsg::Node> node,
+      int i,
+      void* member);
 
-    std::shared_ptr<ChakraProtoMsg::Node> node_{nullptr};
-    std::unordered_set<std::shared_ptr<ETFeederNode>> children_set_{};
-    std::vector<std::shared_ptr<ETFeederNode>> children_vec_{};
-    std::vector<uint64_t> dep_unresolved_parent_ids_{};
+  std::shared_ptr<ChakraProtoMsg::Node> node_{nullptr};
+  std::unordered_set<std::shared_ptr<ETFeederNode>> children_set_{};
+  std::vector<std::shared_ptr<ETFeederNode>> children_vec_{};
+  std::vector<uint64_t> dep_unresolved_parent_ids_{};
 
-    uint64_t id_;
-    std::string name_;
-    bool is_cpu_op_;
-    uint64_t runtime_;
-    uint64_t num_ops_;
-    uint32_t tensor_loc_;
-    uint64_t tensor_size_;
-    ChakraProtoMsg::CollectiveCommType comm_type_;
-    uint32_t involved_dim_size_;
-    std::vector<bool> involved_dim_;
-    uint32_t comm_priority_;
-    uint64_t comm_size_;
-    uint32_t comm_src_;
-    uint32_t comm_dst_;
-    uint32_t comm_tag_;
+  uint64_t id_;
+  std::string name_;
+  bool is_cpu_op_;
+  uint64_t runtime_;
+  uint64_t num_ops_;
+  uint32_t tensor_loc_;
+  uint64_t tensor_size_;
+  ChakraProtoMsg::CollectiveCommType comm_type_;
+  uint32_t involved_dim_size_;
+  std::vector<bool> involved_dim_;
+  uint32_t comm_priority_;
+  uint64_t comm_size_;
+  uint32_t comm_src_;
+  uint32_t comm_dst_;
+  uint32_t comm_tag_;
 };
 
 } // namespace Chakra

--- a/third_party/utils/protoio.hh
+++ b/third_party/utils/protoio.hh
@@ -35,7 +35,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 /**
  * @file
  * Declaration of a wrapper for protobuf output streams and input streams.
@@ -55,28 +54,24 @@
  * A ProtoStream provides the shared functionality of the input and
  * output streams. At the moment this is limited to magic number.
  */
-class ProtoStream
-{
+class ProtoStream {
+ protected:
+  /// Use the ASCII characters gem5 as our magic number
+  static const uint32_t magicNumber = 0x356d6567;
 
-  protected:
+  /**
+   * Create a ProtoStream.
+   */
+  ProtoStream() {}
 
-    /// Use the ASCII characters gem5 as our magic number
-    static const uint32_t magicNumber = 0x356d6567;
-
-    /**
-     * Create a ProtoStream.
-     */
-    ProtoStream() {}
-
-  private:
-
-    /**
-     * Hide the copy constructor and assignment operator.
-     * @{
-     */
-    ProtoStream(const ProtoStream&);
-    ProtoStream& operator=(const ProtoStream&);
-    /** @} */
+ private:
+  /**
+   * Hide the copy constructor and assignment operator.
+   * @{
+   */
+  ProtoStream(const ProtoStream&);
+  ProtoStream& operator=(const ProtoStream&);
+  /** @} */
 };
 
 /**
@@ -87,47 +82,42 @@ class ProtoStream
  * is made possible by encoding the length of each message in the
  * stream.
  */
-class ProtoOutputStream : public ProtoStream
-{
+class ProtoOutputStream : public ProtoStream {
+ public:
+  /**
+   * Create an output stream for a given file name. If the filename
+   * ends with .gz then the file will be compressed accordinly.
+   *
+   * @param filename Path to the file to create or truncate
+   */
+  ProtoOutputStream(const std::string& filename);
 
-  public:
+  /**
+   * Destruct the output stream, and also flush and close the
+   * underlying file streams and coded streams.
+   */
+  ~ProtoOutputStream();
 
-    /**
-     * Create an output stream for a given file name. If the filename
-     * ends with .gz then the file will be compressed accordinly.
-     *
-     * @param filename Path to the file to create or truncate
-     */
-    ProtoOutputStream(const std::string& filename);
+  /**
+   * Write a message to the stream, preprending it with the message
+   * size.
+   *
+   * @param msg Message to write to the stream
+   */
+  void write(const google::protobuf::Message& msg);
 
-    /**
-     * Destruct the output stream, and also flush and close the
-     * underlying file streams and coded streams.
-     */
-    ~ProtoOutputStream();
+ private:
+  /// Underlying file output stream
+  std::ofstream fileStream;
 
-    /**
-     * Write a message to the stream, preprending it with the message
-     * size.
-     *
-     * @param msg Message to write to the stream
-     */
-    void write(const google::protobuf::Message& msg);
+  /// Zero Copy stream wrapping the STL output stream
+  google::protobuf::io::OstreamOutputStream* wrappedFileStream;
 
-  private:
+  /// Optional Gzip stream to wrap the Zero Copy stream
+  google::protobuf::io::GzipOutputStream* gzipStream;
 
-    /// Underlying file output stream
-    std::ofstream fileStream;
-
-    /// Zero Copy stream wrapping the STL output stream
-    google::protobuf::io::OstreamOutputStream* wrappedFileStream;
-
-    /// Optional Gzip stream to wrap the Zero Copy stream
-    google::protobuf::io::GzipOutputStream* gzipStream;
-
-    /// Top-level zero-copy stream, either with compression or not
-    google::protobuf::io::ZeroCopyOutputStream* zeroCopyStream;
-
+  /// Top-level zero-copy stream, either with compression or not
+  google::protobuf::io::ZeroCopyOutputStream* zeroCopyStream;
 };
 
 /**
@@ -137,68 +127,63 @@ class ProtoOutputStream : public ProtoStream
  * huge data structures. The latter assumes the length of each message
  * is encoded in the stream when it is written.
  */
-class ProtoInputStream : public ProtoStream
-{
+class ProtoInputStream : public ProtoStream {
+ public:
+  /**
+   * Create an input stream for a given file name. If the filename
+   * ends with .gz then the file will be decompressed accordingly.
+   *
+   * @param filename Path to the file to read from
+   */
+  ProtoInputStream(const std::string& filename);
 
-  public:
+  /**
+   * Destruct the input stream, and also close the underlying file
+   * streams and coded streams.
+   */
+  ~ProtoInputStream();
 
-    /**
-     * Create an input stream for a given file name. If the filename
-     * ends with .gz then the file will be decompressed accordingly.
-     *
-     * @param filename Path to the file to read from
-     */
-    ProtoInputStream(const std::string& filename);
+  /**
+   * Read a message from the stream.
+   *
+   * @param msg Message read from the stream
+   * @param return True if a message was read, false if reading fails
+   */
+  bool read(google::protobuf::Message& msg);
 
-    /**
-     * Destruct the input stream, and also close the underlying file
-     * streams and coded streams.
-     */
-    ~ProtoInputStream();
+  /**
+   * Reset the input stream and seek to the beginning of the file.
+   */
+  void reset();
 
-    /**
-     * Read a message from the stream.
-     *
-     * @param msg Message read from the stream
-     * @param return True if a message was read, false if reading fails
-     */
-    bool read(google::protobuf::Message& msg);
+ private:
+  /**
+   * Create the internal streams that are wrapping the input file.
+   */
+  void createStreams();
 
-    /**
-     * Reset the input stream and seek to the beginning of the file.
-     */
-    void reset();
+  /**
+   * Destroy the internal streams that are wrapping the input file.
+   */
+  void destroyStreams();
 
-  private:
+  /// Underlying file input stream
+  std::ifstream fileStream;
 
-    /**
-     * Create the internal streams that are wrapping the input file.
-     */
-    void createStreams();
+  /// Hold on to the file name for debug messages
+  const std::string fileName;
 
-    /**
-     * Destroy the internal streams that are wrapping the input file.
-     */
-    void destroyStreams();
+  /// Boolean flag to remember whether we use gzip or not
+  bool useGzip;
 
-    /// Underlying file input stream
-    std::ifstream fileStream;
+  /// Zero Copy stream wrapping the STL input stream
+  google::protobuf::io::IstreamInputStream* wrappedFileStream;
 
-    /// Hold on to the file name for debug messages
-    const std::string fileName;
+  /// Optional Gzip stream to wrap the Zero Copy stream
+  google::protobuf::io::GzipInputStream* gzipStream;
 
-    /// Boolean flag to remember whether we use gzip or not
-    bool useGzip;
-
-    /// Zero Copy stream wrapping the STL input stream
-    google::protobuf::io::IstreamInputStream* wrappedFileStream;
-
-    /// Optional Gzip stream to wrap the Zero Copy stream
-    google::protobuf::io::GzipInputStream* gzipStream;
-
-    /// Top-level zero-copy stream, either with compression or not
-    google::protobuf::io::ZeroCopyInputStream* zeroCopyStream;
-
+  /// Top-level zero-copy stream, either with compression or not
+  google::protobuf::io::ZeroCopyInputStream* zeroCopyStream;
 };
 
 #endif //__PROTO_PROTOIO_HH


### PR DESCRIPTION
## Summary
Implemented clang-format-11 for standardizing the C++ code formatting. This pull request includes the application of clang-format-11 to the existing codebase and the addition of a GitHub Action workflow to ensure ongoing code format consistency.

## Test Plan
```
$ git clone --recurse-submodules git@github.com:astra-sim/astra-sim.git
$ cd ./astra-sim/
$ docker build -t astra-sim .
$ docker run -it astra-sim
$ cd ./extern/graph_frontend/chakra
$ pip3 install .
$ python3 -m chakra.et_generator.et_generator --num_npus 64 --num_dims 1
$ cd -
$ ./build/astra_analytical/build.sh
$ ./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware \
  --workload-configuration=./extern/graph_frontend/chakra/one_comm_coll_node_allreduce \
  --system-configuration=./inputs/system/Switch.json \
  --network-configuration=./inputs/network/analytical/Switch.yml \
  --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
sys[0] finished, 39582 cycles
sys[1] finished, 39582 cycles
sys[2] finished, 39582 cycles
sys[3] finished, 39582 cycles
sys[4] finished, 39582 cycles
sys[5] finished, 39582 cycles
sys[6] finished, 39582 cycles
sys[7] finished, 39582 cycles
sys[8] finished, 39582 cycles
sys[9] finished, 39582 cycles
sys[10] finished, 39582 cycles
sys[11] finished, 39582 cycles
sys[12] finished, 39582 cycles
sys[13] finished, 39582 cycles
sys[14] finished, 39582 cycles
sys[15] finished, 39582 cycles
sys[16] finished, 39582 cycles
sys[17] finished, 39582 cycles
sys[18] finished, 39582 cycles
sys[19] finished, 39582 cycles
sys[20] finished, 39582 cycles
sys[21] finished, 39582 cycles
sys[22] finished, 39582 cycles
sys[23] finished, 39582 cycles
sys[24] finished, 39582 cycles
sys[25] finished, 39582 cycles
sys[26] finished, 39582 cycles
sys[27] finished, 39582 cycles
sys[28] finished, 39582 cycles
sys[29] finished, 39582 cycles
sys[30] finished, 39582 cycles
sys[31] finished, 39582 cycles
sys[32] finished, 39582 cycles
sys[33] finished, 39582 cycles
sys[34] finished, 39582 cycles
sys[35] finished, 39582 cycles
sys[36] finished, 39582 cycles
sys[37] finished, 39582 cycles
sys[38] finished, 39582 cycles
sys[39] finished, 39582 cycles
sys[40] finished, 39582 cycles
sys[41] finished, 39582 cycles
sys[42] finished, 39582 cycles
sys[43] finished, 39582 cycles
sys[44] finished, 39582 cycles
sys[45] finished, 39582 cycles
sys[46] finished, 39582 cycles
sys[47] finished, 39582 cycles
sys[48] finished, 39582 cycles
sys[49] finished, 39582 cycles
sys[50] finished, 39582 cycles
sys[51] finished, 39582 cycles
sys[52] finished, 39582 cycles
sys[53] finished, 39582 cycles
sys[54] finished, 39582 cycles
sys[55] finished, 39582 cycles
sys[56] finished, 39582 cycles
sys[57] finished, 39582 cycles
sys[58] finished, 39582 cycles
sys[59] finished, 39582 cycles
sys[60] finished, 39582 cycles
sys[61] finished, 39582 cycles
sys[62] finished, 39582 cycles
sys[63] finished, 39582 cycles
```
