### PR TITLE
[chakra][et_visualizer] Use the latest schema

### DIFF
--- a/et_visualizer/et_visualizer.py
+++ b/et_visualizer/et_visualizer.py
@@ -8,7 +8,10 @@ from chakra.third_party.utils.protolib import (
     openFileRd as open_file_rd,
     decodeMessage as decode_message
 )
-from chakra.et_def.et_def_pb2 import Node
+from chakra.et_def.et_def_pb2 import (
+    GlobalMetadata,
+    Node,
+)
 
 
 def main() -> None:
@@ -33,10 +36,12 @@ def main() -> None:
 
     et = open_file_rd(args.input_filename)
     node = Node()
+    gm = GlobalMetadata()
 
     # Determine the file type to be created based on the output filename
     if args.output_filename.endswith((".pdf", ".dot")):
         f = graphviz.Digraph()
+        decode_message(et, gm)
         while decode_message(et, node):
             f.node(name=f"{node.id}",
                    label=f"{node.name}",
@@ -59,6 +64,7 @@ def main() -> None:
                      format="dot", cleanup=True)
     elif args.output_filename.endswith(".graphml"):
         G = nx.DiGraph()
+        decode_message(et, gm)
         while decode_message(et, node):
             G.add_node(node.id, label=node.name)
 


### PR DESCRIPTION
## Summary
Ensure that the global metadata is read in the beginning, as mandated in the Chakra schema v0.0.4

## Test Plan
```
$ pip3 install .
$ python3 -m chakra.et_generator.et_generator --num_npus 64 --num_dims 1
$ python3 -m chakra.et_visualizer.et_visualizer --input_filename one_comp_node.0.et --output_filename one_comp_node.0.pdf
$ python3 -m chakra.et_visualizer.et_visualizer --input_filename one_comp_node.0.et --output_filename one_comp_node.0.dot
$ python3 -m chakra.et_visualizer.et_visualizer --input_filename one_comp_node.0.et --output_filename one_comp_node.0.graphml
```
<img width="342" alt="Screenshot 2023-11-23 at 7 41 10 AM" src="https://github.com/mlcommons/chakra/assets/7621438/548e0b2b-4bca-411a-80a8-48f98836dafa">
