### PR TITLE
Add robust error handling for file operations in ETFeeder

### DIFF
--- a/et_feeder/et_feeder.cpp
+++ b/et_feeder/et_feeder.cpp
@@ -5,8 +5,17 @@ using namespace Chakra;
 
 ETFeeder::ETFeeder(string filename)
   : trace_(filename), window_size_(4096 * 256), et_complete_(false) {
-  readGlobalMetadata();
-  readNextWindow();
+  if (!trace_.is_open()) { // Assuming a method to check if file is open
+    throw std::runtime_error("Failed to open trace file: " + filename);
+  }
+
+  try {
+    readGlobalMetadata();
+    readNextWindow();
+  } catch (const std::exception& e) {
+    cerr << "Error in constructor: " << e.what() << endl;
+    throw;  // Rethrow the exception for caller to handle
+  }
 }
 
 ETFeeder::~ETFeeder() {
@@ -70,6 +79,9 @@ void ETFeeder::freeChildrenNodes(uint64_t node_id) {
 }
 
 void ETFeeder::readGlobalMetadata() {
+  if (!trace_.is_open()) {
+    throw runtime_error("Trace file closed unexpectedly during reading global metadata.");
+  }
   shared_ptr<ChakraProtoMsg::GlobalMetadata> pkt_msg = make_shared<ChakraProtoMsg::GlobalMetadata>();
   trace_.read(*pkt_msg);
 }
@@ -124,6 +136,9 @@ void ETFeeder::resolveDep() {
 }
 
 void ETFeeder::readNextWindow() {
+  if (!trace_.is_open()) {
+    throw runtime_error("Trace file closed unexpectedly during reading next window.");
+  }
   uint32_t num_read = 0;
   do {
     shared_ptr<ETFeederNode> new_node = readNode();


### PR DESCRIPTION
## Summary
This pull request introduces comprehensive error handling for file operations in the `ETFeeder` class.

## Test Plan
```
$ git clone --recurse-submodules git@github.com:astra-sim/astra-sim.git
$ cd ./astra-sim/
$ docker build -t astra-sim .
$ docker run -it astra-sim
$ cd ./extern/graph_frontend/chakra
$ pip3 install .
$ python3 -m chakra.et_generator.et_generator --num_npus 64 --num_dims 1
$ cd -
$ ./build/astra_analytical/build.sh
$ ./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware \
  --workload-configuration=./extern/graph_frontend/chakra/one_comm_coll_node_allreduce \
  --system-configuration=./inputs/system/Switch.json \
  --network-configuration=./inputs/network/analytical/Switch.yml \
  --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
sys[0] finished, 39582 cycles
sys[1] finished, 39582 cycles
sys[2] finished, 39582 cycles
sys[3] finished, 39582 cycles
sys[4] finished, 39582 cycles
sys[5] finished, 39582 cycles
sys[6] finished, 39582 cycles
sys[7] finished, 39582 cycles
sys[8] finished, 39582 cycles
sys[9] finished, 39582 cycles
sys[10] finished, 39582 cycles
sys[11] finished, 39582 cycles
sys[12] finished, 39582 cycles
sys[13] finished, 39582 cycles
sys[14] finished, 39582 cycles
sys[15] finished, 39582 cycles
sys[16] finished, 39582 cycles
sys[17] finished, 39582 cycles
sys[18] finished, 39582 cycles
sys[19] finished, 39582 cycles
sys[20] finished, 39582 cycles
sys[21] finished, 39582 cycles
sys[22] finished, 39582 cycles
sys[23] finished, 39582 cycles
sys[24] finished, 39582 cycles
sys[25] finished, 39582 cycles
sys[26] finished, 39582 cycles
sys[27] finished, 39582 cycles
sys[28] finished, 39582 cycles
sys[29] finished, 39582 cycles
sys[30] finished, 39582 cycles
sys[31] finished, 39582 cycles
sys[32] finished, 39582 cycles
sys[33] finished, 39582 cycles
sys[34] finished, 39582 cycles
sys[35] finished, 39582 cycles
sys[36] finished, 39582 cycles
sys[37] finished, 39582 cycles
sys[38] finished, 39582 cycles
sys[39] finished, 39582 cycles
sys[40] finished, 39582 cycles
sys[41] finished, 39582 cycles
sys[42] finished, 39582 cycles
sys[43] finished, 39582 cycles
sys[44] finished, 39582 cycles
sys[45] finished, 39582 cycles
sys[46] finished, 39582 cycles
sys[47] finished, 39582 cycles
sys[48] finished, 39582 cycles
sys[49] finished, 39582 cycles
sys[50] finished, 39582 cycles
sys[51] finished, 39582 cycles
sys[52] finished, 39582 cycles
sys[53] finished, 39582 cycles
sys[54] finished, 39582 cycles
sys[55] finished, 39582 cycles
sys[56] finished, 39582 cycles
sys[57] finished, 39582 cycles
sys[58] finished, 39582 cycles
sys[59] finished, 39582 cycles
sys[60] finished, 39582 cycles
sys[61] finished, 39582 cycles
sys[62] finished, 39582 cycles
sys[63] finished, 39582 cycles
$ cd -
$ rm *.et
$ ./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware \
  --workload-configuration=./extern/graph_frontend/chakra/one_comm_coll_node_allreduce \
  --system-configuration=./inputs/system/Switch.json \
  --network-configuration=./inputs/network/analytical/Switch.yml \
  --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
workload file: ./extern/graph_frontend/chakra/one_comm_coll_node_allreduce.0.et does not exist
```