### PR TITLE
fix AttributeError: 'Node' object has no attribute 'parent'

### DIFF
--- a/et_def/et_def.proto
+++ b/et_def/et_def.proto
@@ -145,6 +145,7 @@ message Node {
   IOInfo inputs = 8;
   IOInfo outputs = 9;
   repeated AttributeProto attr = 10;
+  repeated uint64 parent = 11;
 }
 
 message IOInfo {


### PR DESCRIPTION
Converting from ASTRA-sim-1.0 Text Files to Chakra format triggers the following attribute error.
![20231128001401](https://github.com/mlcommons/chakra/assets/68851203/4b4b2e14-7c73-4af1-ada1-db821d874ea5)
This PR fixes the error.
