### PR TITLE
Add missing is_open() to ProtoInputStream

### DIFF
--- a/third_party/utils/protoio.cc
+++ b/third_party/utils/protoio.cc
@@ -155,6 +155,10 @@ void ProtoInputStream::reset() {
   createStreams();
 }
 
+bool ProtoInputStream::is_open() {
+  return fileStream.is_open();
+}
+
 bool ProtoInputStream::read(Message& msg) {
   // Read a message from the stream by getting the size, using it as
   // a limit when parsing the message, then popping the limit again

--- a/third_party/utils/protoio.hh
+++ b/third_party/utils/protoio.hh
@@ -143,6 +143,8 @@ class ProtoInputStream : public ProtoStream {
    */
   ~ProtoInputStream();
 
+  bool is_open();
+
   /**
    * Read a message from the stream.
    *


### PR DESCRIPTION
## Summary
is_open() function was missing in ProtoInputStream, and this PR fixes the bug.

## Test Plan
```
$ cd ./astra-sim/
$ docker build -t astra-sim .
$ docker run -it astra-sim
$ cd ./extern/graph_frontend/chakra
$ pip3 install .
$ python3 -m chakra.et_generator.et_generator --num_npus 64 --num_dims 1
$ cd -
$ ./build/astra_analytical/build.sh
$ ./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware \
  --workload-configuration=./extern/graph_frontend/chakra/one_comm_coll_node_allreduce \
  --system-configuration=./inputs/system/Switch.json \
  --network-configuration=./inputs/network/analytical/Switch.yml \
  --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
ring of node 0, id: 0 dimension: local total nodes in ring: 64 index in ring: 0 offset: 1total nodes in ring: 64
sys[0] finished, 39582 cycles
sys[1] finished, 39582 cycles
sys[2] finished, 39582 cycles
sys[3] finished, 39582 cycles
sys[4] finished, 39582 cycles
sys[5] finished, 39582 cycles
sys[6] finished, 39582 cycles
sys[7] finished, 39582 cycles
sys[8] finished, 39582 cycles
sys[9] finished, 39582 cycles
sys[10] finished, 39582 cycles
sys[11] finished, 39582 cycles
sys[12] finished, 39582 cycles
sys[13] finished, 39582 cycles
sys[14] finished, 39582 cycles
sys[15] finished, 39582 cycles
sys[16] finished, 39582 cycles
sys[17] finished, 39582 cycles
sys[18] finished, 39582 cycles
sys[19] finished, 39582 cycles
sys[20] finished, 39582 cycles
sys[21] finished, 39582 cycles
sys[22] finished, 39582 cycles
sys[23] finished, 39582 cycles
sys[24] finished, 39582 cycles
sys[25] finished, 39582 cycles
sys[26] finished, 39582 cycles
sys[27] finished, 39582 cycles
sys[28] finished, 39582 cycles
sys[29] finished, 39582 cycles
sys[30] finished, 39582 cycles
sys[31] finished, 39582 cycles
sys[32] finished, 39582 cycles
sys[33] finished, 39582 cycles
sys[34] finished, 39582 cycles
sys[35] finished, 39582 cycles
sys[36] finished, 39582 cycles
sys[37] finished, 39582 cycles
sys[38] finished, 39582 cycles
sys[39] finished, 39582 cycles
sys[40] finished, 39582 cycles
sys[41] finished, 39582 cycles
sys[42] finished, 39582 cycles
sys[43] finished, 39582 cycles
sys[44] finished, 39582 cycles
sys[45] finished, 39582 cycles
sys[46] finished, 39582 cycles
sys[47] finished, 39582 cycles
sys[48] finished, 39582 cycles
sys[49] finished, 39582 cycles
sys[50] finished, 39582 cycles
sys[51] finished, 39582 cycles
sys[52] finished, 39582 cycles
sys[53] finished, 39582 cycles
sys[54] finished, 39582 cycles
sys[55] finished, 39582 cycles
sys[56] finished, 39582 cycles
sys[57] finished, 39582 cycles
sys[58] finished, 39582 cycles
sys[59] finished, 39582 cycles
sys[60] finished, 39582 cycles
sys[61] finished, 39582 cycles
sys[62] finished, 39582 cycles
sys[63] finished, 39582 cycles
```